### PR TITLE
add close icon button to `Modal`

### DIFF
--- a/components/modals/assetList.tsx
+++ b/components/modals/assetList.tsx
@@ -21,10 +21,6 @@ const AssetListModal = ({
   const { connected, network } = useContext(WalletContext)
   const { markets } = useContext(TradeContext)
 
-  const handleClose = () => {
-    closeModal(ModalIds.AssetList)
-  }
-
   const handleClick = (a: Coin) => {
     closeModal(ModalIds.AssetList)
     if (side === 'dest') setDestAsset(a)
@@ -43,11 +39,6 @@ const AssetListModal = ({
 
   return (
     <Modal id={ModalIds.AssetList}>
-      <button
-        className="delete is-danger is-large"
-        aria-label="close"
-        onClick={handleClose}
-      />
       <div className="columns">
         <div className="column is-half is-offset-one-quarter">
           <h1 className="title has-text-white">Select an asset</h1>

--- a/components/modals/assetList.tsx
+++ b/components/modals/assetList.tsx
@@ -21,6 +21,10 @@ const AssetListModal = ({
   const { connected, network } = useContext(WalletContext)
   const { markets } = useContext(TradeContext)
 
+  const handleClose = () => {
+    closeModal(ModalIds.AssetList)
+  }
+
   const handleClick = (a: Coin) => {
     closeModal(ModalIds.AssetList)
     if (side === 'dest') setDestAsset(a)
@@ -39,6 +43,11 @@ const AssetListModal = ({
 
   return (
     <Modal id={ModalIds.AssetList}>
+      <button
+        className="delete is-danger is-large"
+        aria-label="close"
+        onClick={handleClose}
+      />
       <div className="columns">
         <div className="column is-half is-offset-one-quarter">
           <h1 className="title has-text-white">Select an asset</h1>

--- a/components/modals/modal.tsx
+++ b/components/modals/modal.tsx
@@ -27,8 +27,16 @@ const Modal = ({ children, id, reset }: ModalProps) => {
   return (
     <div className="modal" id={id}>
       <div onClick={handleClick} className="modal-background" />
+
       <div className="modal-content box has-background-black">
-        <div style={{ minHeight: '25rem' }}>{children}</div>
+        <div style={{ minHeight: '25rem' }}>
+          <button
+            className="delete is-large"
+            aria-label="close"
+            onClick={handleClick}
+          />
+          {children}
+        </div>
       </div>
     </div>
   )

--- a/components/trade/input.tsx
+++ b/components/trade/input.tsx
@@ -22,9 +22,10 @@ export default function CoinInput({
     const { value } = e.target
     setValue(value)
     setInvalid(isNaN(Number(value)))
-    const amount = isNaN(Number(value)) || value === ''
-      ? undefined
-      : toSatoshis(Number(value), coin.precision)
+    const amount =
+      isNaN(Number(value)) || value === ''
+        ? undefined
+        : toSatoshis(Number(value), coin.precision)
     setAmount(amount)
   }
 


### PR DESCRIPTION
Due to bad black contrast on my cheap monitor, I'm not able to see the borders of the modal. This PR adds a white cross letting to close Select asset menu without clicking outside the modal.

@bordalix please review